### PR TITLE
Change UIWebView (deprecated since iOS 12.0) to WKWebView

### DIFF
--- a/ios/Classes/FlutterUserAgentPlugin.h
+++ b/ios/Classes/FlutterUserAgentPlugin.h
@@ -1,7 +1,9 @@
 #import <sys/utsname.h>
 #import <UIKit/UIKit.h>
 #import <Flutter/Flutter.h>
+#import <WebKit/WebKit.h>
 
 @interface FlutterUserAgentPlugin : NSObject<FlutterPlugin>
 @property (nonatomic) bool isEmulator;
+@property (nonatomic) WKWebView* webView;
 @end

--- a/ios/Classes/FlutterUserAgentPlugin.h
+++ b/ios/Classes/FlutterUserAgentPlugin.h
@@ -5,5 +5,5 @@
 
 @interface FlutterUserAgentPlugin : NSObject<FlutterPlugin>
 @property (nonatomic) bool isEmulator;
-@property (nonatomic) WKWebView* webView;
+@property (nonatomic) WKWebView* webView API_AVAILABLE(ios(8.0));
 @end

--- a/ios/Classes/FlutterUserAgentPlugin.m
+++ b/ios/Classes/FlutterUserAgentPlugin.m
@@ -1,5 +1,4 @@
 #import "FlutterUserAgentPlugin.h"
-#import <WebKit/WebKit.h>
 
 @implementation FlutterUserAgentPlugin
 
@@ -22,6 +21,7 @@
 }
 
 @synthesize isEmulator;
+@synthesize webView;
 
 //eg. Darwin/16.3.0
 - (NSString *)darwinVersion
@@ -151,8 +151,13 @@
 
 - (void)getWebViewUserAgent:(void (^ _Nullable)(_Nullable id, NSError * _Nullable error))completionHandler;
 {
-    WKWebView* webView = [[WKWebView alloc] init];
-    [webView evaluateJavaScript:@"navigator.userAgent" completionHandler:completionHandler];
+    if (self.webView == nil) {
+        // retain because `evaluateJavaScript:` is asynchronous
+        self.webView = [[WKWebView alloc] init];
+    }
+    
+    [self.webView loadHTMLString:@"<html></html>" baseURL:nil];
+    [self.webView evaluateJavaScript:@"navigator.userAgent" completionHandler:completionHandler];
 }
 
 - (void)constantsToExport:(void  (^ _Nullable)(NSDictionary * _Nonnull constants))completionHandler
@@ -169,6 +174,7 @@
     NSString *userAgent = [NSString stringWithFormat:@"CFNetwork/%@ Darwin/%@ (%@ %@/%@)", cfnVersion, darwinVersion, deviceName, currentDevice.systemName, currentDevice.systemVersion];
 
     [self getWebViewUserAgent:^(id _Nullable webViewUserAgent, NSError * _Nullable error) {
+        NSLog(@"%@", webViewUserAgent);
         completionHandler(@{
           @"isEmulator": @(self.isEmulator),
           @"systemName": currentDevice.systemName,
@@ -184,6 +190,7 @@
           @"webViewUserAgent": webViewUserAgent ?: [NSNull null]
         });
     }];
+
 }
 
 @end


### PR DESCRIPTION
This pr removes the need of the deprecated UIWebView on iOS 8.0+ and uses the WKWebView instead as noted in the official UIWebView documentation:

> Note
> 
> In apps that run in iOS 8 and later, use the WKWebView class instead of using UIWebView. Additionally, consider setting the WKPreferences property javaScriptEnabled to false if you render files that are not supposed to run JavaScript.

see: https://developer.apple.com/documentation/uikit/uiwebview