### PR TITLE
Fix for No podspec found for `flutter_user_agentx'

### DIFF
--- a/ios/flutter_user_agentx.podspec
+++ b/ios/flutter_user_agentx.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name             = 'flutter_user_agent'
+  s.name             = 'flutter_user_agentx'
   s.version          = '1.2.2'
   s.summary          = 'Retrieve user-agent properties.'
   s.description      = <<-DESC


### PR DESCRIPTION
Not sure if I did this right since I don't really work on iOS as much as android.